### PR TITLE
bug_report: Request information about previously working version.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,6 +13,13 @@ assignees: ''
 **Android version:** 
 **Software binaries version:** 
 
+**Previously working on**
+Has this always been a problem, or is it a new issue?
+<!-- Please be specific. Include things like previous sync and build date,
+the latest known working kernel version including commit id and any other
+information that may be relevant. If possible and applicable, include such
+information from other repositories too (device, platform or hardware). -->
+
 **Description**
 Write the issue description here.
 


### PR DESCRIPTION
Currently we receive many reports that do not include any information at
all about previously working versions. While we are generally able to
connect a new issue to a change merged recently it is much easier for us
to receive this information in the report directly, instead of having to
ask for it.
Besides new contributors might be incentivized to perform research on
their own when asked for such information, perhaps resolving the issue
when the change is small.