### PR TITLE
README: Remove `WIP` status on Mark IV and Mark V devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ https://developer.sony.com/develop/open-devices/guides/aosp-build-instructions/
 | Xperia 5 V <sup>WIP</sup> | [pdx237](https://github.com/sonyxperiadev/device-sony-pdx237) |
 |||
 || _[zambezi](https://github.com/sonyxperiadev/device-sony-zambezi) board_ (**SM6375**, Snapdragon 695 5G) |
-| Xperia 10 V <sup>WIP</sup> | [pdx235](https://github.com/sonyxperiadev/device-sony-pdx235) |
+| Xperia 10 V | [pdx235](https://github.com/sonyxperiadev/device-sony-pdx235) |
 |||
 || _[nagara](https://github.com/sonyxperiadev/device-sony-nagara) board_ (**SM8450**, Snapdragon 8 Gen 1) |
 | Xperia 1 IV | [pdx223](https://github.com/sonyxperiadev/device-sony-pdx223) |
 | Xperia 5 IV | [pdx224](https://github.com/sonyxperiadev/device-sony-pdx224) |
 |||
 || _[murray](https://github.com/sonyxperiadev/device-sony-murray) board_ (**SM6375**, Snapdragon 695 5G) |
-| Xperia 10 IV <sup>WIP</sup> | [pdx225](https://github.com/sonyxperiadev/device-sony-pdx225) |
+| Xperia 10 IV | [pdx225](https://github.com/sonyxperiadev/device-sony-pdx225) |
 |||
 || _[sagami](https://github.com/sonyxperiadev/device-sony-sagami) board_ (**SM8350**, Snapdragon 888) |
 | Xperia 1 III | [pdx215](https://github.com/sonyxperiadev/device-sony-pdx215) |

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ https://developer.sony.com/develop/open-devices/guides/aosp-build-instructions/
 | Xperia 10 VI <sup>Announced</sup> | [pdx246](https://github.com/sonyxperiadev/device-sony-pdx246) |
 |||
 || _[yodo](https://github.com/sonyxperiadev/device-sony-yodo) board_ (**SM8550**, Snapdragon 8 Gen 2) |
-| Xperia 1 V <sup>WIP</sup> | [pdx234](https://github.com/sonyxperiadev/device-sony-pdx234) |
-| Xperia 5 V <sup>WIP</sup> | [pdx237](https://github.com/sonyxperiadev/device-sony-pdx237) |
+| Xperia 1 V | [pdx234](https://github.com/sonyxperiadev/device-sony-pdx234) |
+| Xperia 5 V | [pdx237](https://github.com/sonyxperiadev/device-sony-pdx237) |
 |||
 || _[zambezi](https://github.com/sonyxperiadev/device-sony-zambezi) board_ (**SM6375**, Snapdragon 695 5G) |
 | Xperia 10 V | [pdx235](https://github.com/sonyxperiadev/device-sony-pdx235) |


### PR DESCRIPTION
Murray and Zambezi deserve the `WIP` label removal the most. Because they received full functional support.
Yodo essentially has the same functionality status as Nagara.